### PR TITLE
Automate binary release through github action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches: [ main ]
     tags:
-  # pull_request:
-  #   branches: [ main ]
 
 jobs:
   macos:
@@ -43,10 +41,7 @@ jobs:
           name: wheels
           path: dist
       - name: Archive binary
-        run: |
-          cd target/release
-          tar czvf roapi-http.tar.gz roapi-http
-          cd -
+        run: tar czvf target/release/roapi-http.tar.gz -C target/release roapi-http
       - name: Upload binary to GitHub Release
         uses: svenstaro/upload-release-action@v2
         if: "startsWith(github.ref, 'refs/tags/')"
@@ -117,17 +112,14 @@ jobs:
           name: wheels
           path: dist
       - name: Archive binary
-        run: |
-          cd target/${{ matrix.platform.target }}/release
-          tar czvf roapi-http.tar.gz roapi-http
-          cd -
+        run: tar czvf target/release/roapi-http.tar.gz -C target/${{ matrix.platform.target }}/release roapi-http
       - name: Upload binary to GitHub Release
         uses: svenstaro/upload-release-action@v2
         if: "startsWith(github.ref, 'refs/tags/')"
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           asset_name: roapi-http-${{ matrix.platform.target }}.tar.gz
-          file: target/${{ matrix.platform.target }}/release/roapi-http.tar.gz
+          file: target/release/roapi-http.tar.gz
           tag: ${{ github.ref }}
 
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,151 @@
+name: release
+
+on:
+  push:
+    branches: [ main ]
+    tags:
+  # pull_request:
+  #   branches: [ main ]
+
+jobs:
+  macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.6
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: aarch64-apple-darwin
+          profile: minimal
+          default: true
+      - name: Install maturin
+        run: pip install maturin
+      - name: Build wheels - x86_64
+        run: |
+          maturin build -m roapi-http/Cargo.toml -b bin --target x86_64-apple-darwin --release --out dist
+          pip install roapi-http --no-index --find-links dist --force-reinstall
+      - name: Build wheels - universal2
+        env:
+          DEVELOPER_DIR: /Applications/Xcode.app/Contents/Developer
+          MACOSX_DEPLOYMENT_TARGET: '10.9'
+        run: |
+          # set SDKROOT for C dependencies
+          export SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
+          maturin build -m roapi-http/Cargo.toml -b bin --release --universal2 --out dist --no-sdist
+          pip install roapi-http --no-index --find-links dist --force-reinstall
+      - name: Upload wheels
+        uses: actions/upload-artifact@v2
+        with:
+          name: wheels
+          path: dist
+      - name: Archive binary
+        run: |
+          cd target/release
+          tar czvf roapi-http.tar.gz roapi-http
+          cd -
+      - name: Upload binary to GitHub Release
+        uses: svenstaro/upload-release-action@v2
+        if: "startsWith(github.ref, 'refs/tags/')"
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          asset_name: roapi-http-apple-darwin.tar.gz
+          file: target/release/roapi-http.tar.gz
+          tag: ${{ github.ref }}
+
+  windows:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        platform: [
+          { python-architecture: "x64", target: "x86_64-pc-windows-msvc" },
+          { python-architecture: "x86", target: "i686-pc-windows-msvc" },
+        ]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.6
+          architecture: ${{ matrix.platform.python-architecture }}
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: ${{ matrix.platform.target }}
+          profile: minimal
+          default: true
+      - name: Install maturin
+        run: pip install maturin
+      - name: Build wheels
+        run: |
+          maturin build -m roapi-http/Cargo.toml -b bin --release --out dist --no-sdist --target ${{ matrix.platform.target }}
+          pip install roapi-http --no-index --find-links dist --force-reinstall
+          roapi-http --help
+      - name: Upload wheels
+        uses: actions/upload-artifact@v2
+        with:
+          name: wheels
+          path: dist
+
+  linux:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform: [
+          { manylinux: '2010', target: "x86_64-unknown-linux-musl", image_tag: "x86_64-musl" },
+          { manylinux: '2010', target: "i686-unknown-linux-musl", image_tag: "i686-musl" },
+          { manylinux: '2014', target: "aarch64-unknown-linux-musl", image_tag: "aarch64-musl" },
+          { manylinux: '2014', target: "armv7-unknown-linux-musleabihf", image_tag: "armv7-musleabihf" },
+        ]
+    container:
+      image: docker://benfred/rust-musl-cross:${{ matrix.platform.image_tag }}
+      env:
+        RUSTUP_HOME: /root/.rustup
+        CARGO_HOME: /root/.cargo
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build Wheels
+        run: |
+          pip3 install maturin
+          maturin build -m roapi-http/Cargo.toml -b bin --no-sdist --release -o dist --target ${{ matrix.platform.target }} --manylinux ${{ matrix.platform.manylinux }}
+      - name: Upload wheels
+        uses: actions/upload-artifact@v2
+        with:
+          name: wheels
+          path: dist
+      - name: Archive binary
+        run: |
+          cd target/${{ matrix.platform.target }}/release
+          tar czvf roapi-http.tar.gz roapi-http
+          cd -
+      - name: Upload binary to GitHub Release
+        uses: svenstaro/upload-release-action@v2
+        if: "startsWith(github.ref, 'refs/tags/')"
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          asset_name: roapi-http-${{ matrix.platform.target }}.tar.gz
+          file: target/${{ matrix.platform.target }}/release/roapi-http.tar.gz
+          tag: ${{ github.ref }}
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    if: "startsWith(github.ref, 'refs/tags/')"
+    needs: [ linux, macos, windows ]
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: wheels
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Publish to PyPi
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: |
+          pip install --upgrade twine
+          twine upload --skip-existing *


### PR DESCRIPTION
This PR adds automated binary release to GitHub Release and PyPI.

Example run: https://github.com/messense/roapi/actions/runs/650339382

Fixes #22 