### PR TITLE
Enable SIMD feature for docker build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   # NOTE: this env is also defined in roapi_http_release.yml and columnq_cli_release.yml
-  RUST_TC_NIGHTLY_VER: "2021-07-17"
+  RUST_TC_NIGHTLY_VER: "2021-09-25"
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
       run: cargo test
     - name: Trim cache
       run: |
-        cargo install cargo-cache
+        cargo install --force cargo-cache
         cargo cache trim -l 1G
 
   simd_test:
@@ -71,7 +71,7 @@ jobs:
       run: cargo test --features simd
     - name: Trim cache
       run: |
-        cargo install cargo-cache
+        cargo install --force cargo-cache
         cargo cache trim -l 1G
 
   docker_build:

--- a/.github/workflows/columnq_cli_release.yml
+++ b/.github/workflows/columnq_cli_release.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   # NOTE: this env is also defined in build.yml
-  RUST_TC_NIGHTLY_VER: "2021-07-17"
+  RUST_TC_NIGHTLY_VER: "2021-09-25"
 
 jobs:
   # skip tag version validation on non-release branch run

--- a/.github/workflows/roapi_http_release.yml
+++ b/.github/workflows/roapi_http_release.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   # NOTE: this env is also defined in build.yml
-  RUST_TC_NIGHTLY_VER: "2021-07-17"
+  RUST_TC_NIGHTLY_VER: "2021-09-25"
 
 jobs:
   validate-release-tag:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1671,9 +1671,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e0d047c1062aa51e256408c560894e5251f08925980e53cf1aa5bd00eec6512"
+checksum = "74e768dff5fb39a41b3bcd30bb25cf989706c90d028d1ad71971987aa309d535"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -1821,9 +1821,9 @@ dependencies = [
 
 [[package]]
 name = "packed_simd_2"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e64858a2d3733fdd61adfdd6da89aa202f7ff0e741d2fc7ed1e452ba9dc99d7"
+checksum = "71c0c06716cfc81616fa8e22b721ce92fecd594508bc0eb3d04ae3ef35ac10c5"
 dependencies = [
  "cfg-if 0.1.10",
  "libm",

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM rust:1.55 as builder
+FROM instrumentisto/rust:nightly-bullseye-2021-09-24 AS builder
 WORKDIR /roapi_src
 COPY ./ /roapi_src
-RUN cargo install --locked --path ./roapi-http --bin roapi-http
+RUN cargo install --locked --features simd --path ./roapi-http --bin roapi-http
 
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 LABEL org.opencontainers.image.source https://github.com/roapi/roapi
 
 RUN apt-get update && apt-get install -y libssl-dev && rm -rf /var/lib/apt/lists/*

--- a/columnq/src/table/google_spreadsheets.rs
+++ b/columnq/src/table/google_spreadsheets.rs
@@ -56,6 +56,7 @@ struct Spreadsheets {
     // see: https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets
 }
 
+#[allow(dead_code)]
 #[derive(Deserialize, Debug)]
 struct SpreadsheetValues {
     range: String,


### PR DESCRIPTION
This PR enables SIMD for the Docker build. It uses an image which is referred to in https://github.com/rust-lang/docker-rust-nightly/issues/3#issuecomment-653419224

These docker images get tagged with the version of `rustc --version` which is different than the installed version with `rustup`. This is why the dates are different. 

I took the liberty to update the nightly version and needed to apply some fixes for that.

Some ideas:

- We could have a matrix build with a fixed nightly version and one is testing with the most current? Or we could do a daily build for the most recent nightly
- Instead of a separate build in the Dockerfile, we can add a target to the Linux release target (and the main build) and copy the binary in the Dockerfile. Alternatively we can reuse the musl target for that. This would save some redundant building?

Fixes #15