### PR TITLE
Build wheels with rustls

### DIFF
--- a/.github/workflows/columnq_cli_release.yml
+++ b/.github/workflows/columnq_cli_release.yml
@@ -121,13 +121,13 @@ jobs:
       fail-fast: false
       matrix:
         platform: [
-#          { manylinux: '2010', target: "x86_64-unknown-linux-musl", image_tag: "x86_64-musl", features: "simd,rustls" },
-          { manylinux: '2010', target: "x86_64-unknown-linux-musl", image_tag: "x86_64-musl", features: "simd,native-tls-vendored" },
+          { manylinux: '2010', target: "x86_64-unknown-linux-musl", image_tag: "x86_64-musl", features: "simd,rustls", upload: "true" },
+          { manylinux: '2010', target: "x86_64-unknown-linux-musl", image_tag: "x86_64-musl", features: "simd,native-tls-vendored", upload: "false" },
           # { manylinux: '2010', target: "i686-unknown-linux-musl", image_tag: "i686-musl", features: "" },
-#          { manylinux: '2014', target: "aarch64-unknown-linux-musl", image_tag: "aarch64-musl", features: "rustls" },
-          { manylinux: '2014', target: "aarch64-unknown-linux-musl", image_tag: "aarch64-musl", features: "native-tls-vendored" },
-#          { manylinux: '2014', target: "armv7-unknown-linux-musleabihf", image_tag: "armv7-musleabihf", features: "rustls" },
-          { manylinux: '2014', target: "armv7-unknown-linux-musleabihf", image_tag: "armv7-musleabihf", features: "native-tls-vendored" },
+          { manylinux: '2014', target: "aarch64-unknown-linux-musl", image_tag: "aarch64-musl", features: "rustls", upload: "true" },
+          { manylinux: '2014', target: "aarch64-unknown-linux-musl", image_tag: "aarch64-musl", features: "native-tls-vendored", upload: "false" },
+          { manylinux: '2014', target: "armv7-unknown-linux-musleabihf", image_tag: "armv7-musleabihf", features: "rustls", upload: "true" },
+          { manylinux: '2014', target: "armv7-unknown-linux-musleabihf", image_tag: "armv7-musleabihf", features: "native-tls-vendored", upload: "false" },
         ]
     container:
       image: docker://messense/rust-musl-cross:${{ matrix.platform.image_tag }}
@@ -151,14 +151,16 @@ jobs:
             --cargo-extra-args="--no-default-features --features=${{ matrix.platform.features }}"
       - name: Upload wheels
         uses: actions/upload-artifact@v2
+        if: "matrix.platform.upload == 'true'"
         with:
           name: wheels
           path: dist
       - name: Archive binary
+        if: "matrix.platform.upload == 'true'"
         run: tar czvf target/release/columnq-cli.tar.gz -C target/${{ matrix.platform.target }}/release columnq
       - name: Upload binary to GitHub Release
         uses: svenstaro/upload-release-action@v2
-        if: "startsWith(github.ref, 'refs/tags/')"
+        if: "startsWith(github.ref, 'refs/tags/') && matrix.platform.upload == 'true'"
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           asset_name: columnq-cli-${{ matrix.platform.target }}.tar.gz

--- a/.github/workflows/columnq_cli_release.yml
+++ b/.github/workflows/columnq_cli_release.yml
@@ -3,10 +3,11 @@ name: columnq-cli release
 on:
   push:
     paths:
+      - '.github/workflows/columnq_cli_release.yml'
       - 'columnq/**'
       - 'columnq-cli/**'
       - 'Cargo.lock'
-    branches: [ main ]
+    branches: [ main, rustls ]
     tags: [ 'columnq-cli-v*' ]
 
 env:
@@ -117,6 +118,7 @@ jobs:
     needs: validate-release-tag
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         platform: [
           { manylinux: '2010', target: "x86_64-unknown-linux-musl", image_tag: "x86_64-musl", features: "simd" },
@@ -125,7 +127,7 @@ jobs:
           { manylinux: '2014', target: "armv7-unknown-linux-musleabihf", image_tag: "armv7-musleabihf", features: "" },
         ]
     container:
-      image: docker://benfred/rust-musl-cross:${{ matrix.platform.image_tag }}
+      image: docker://messense/rust-musl-cross:${{ matrix.platform.image_tag }}
       env:
         RUSTUP_HOME: /root/.rustup
         CARGO_HOME: /root/.cargo
@@ -140,7 +142,7 @@ jobs:
           rustup default nightly-${{ env.RUST_TC_NIGHTLY_VER }}
       - name: Build Wheels
         run: |
-          pip3 install 'maturin<0.12'
+          sudo python3 -m pip install maturin
           maturin build -m columnq-cli/Cargo.toml -b bin --no-sdist --release -o dist \
             --target ${{ matrix.platform.target }} --manylinux ${{ matrix.platform.manylinux }} \
             --cargo-extra-args="--features=${{ matrix.platform.features }}"

--- a/.github/workflows/columnq_cli_release.yml
+++ b/.github/workflows/columnq_cli_release.yml
@@ -121,10 +121,13 @@ jobs:
       fail-fast: false
       matrix:
         platform: [
-          { manylinux: '2010', target: "x86_64-unknown-linux-musl", image_tag: "x86_64-musl", features: "simd" },
+          { manylinux: '2010', target: "x86_64-unknown-linux-musl", image_tag: "x86_64-musl", features: "simd,rustls" },
+          { manylinux: '2010', target: "x86_64-unknown-linux-musl", image_tag: "x86_64-musl", features: "simd,native-tls-vendored" },
           # { manylinux: '2010', target: "i686-unknown-linux-musl", image_tag: "i686-musl", features: "" },
-          { manylinux: '2014', target: "aarch64-unknown-linux-musl", image_tag: "aarch64-musl", features: "" },
-          { manylinux: '2014', target: "armv7-unknown-linux-musleabihf", image_tag: "armv7-musleabihf", features: "" },
+          { manylinux: '2014', target: "aarch64-unknown-linux-musl", image_tag: "aarch64-musl", features: "rustls" },
+          { manylinux: '2014', target: "aarch64-unknown-linux-musl", image_tag: "aarch64-musl", features: "native-tls-vendored" },
+          { manylinux: '2014', target: "armv7-unknown-linux-musleabihf", image_tag: "armv7-musleabihf", features: "rustls" },
+          { manylinux: '2014', target: "armv7-unknown-linux-musleabihf", image_tag: "armv7-musleabihf", features: "native-tls-vendored" },
         ]
     container:
       image: docker://messense/rust-musl-cross:${{ matrix.platform.image_tag }}
@@ -145,7 +148,7 @@ jobs:
           sudo python3 -m pip install 'maturin<0.12'
           maturin build -m columnq-cli/Cargo.toml -b bin --no-sdist --release -o dist \
             --target ${{ matrix.platform.target }} --manylinux ${{ matrix.platform.manylinux }} \
-            --cargo-extra-args="--features=${{ matrix.platform.features }}"
+            --cargo-extra-args="--no-default-features --features=${{ matrix.platform.features }}"
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/columnq_cli_release.yml
+++ b/.github/workflows/columnq_cli_release.yml
@@ -142,7 +142,7 @@ jobs:
           rustup default nightly-${{ env.RUST_TC_NIGHTLY_VER }}
       - name: Build Wheels
         run: |
-          sudo python3 -m pip install maturin
+          sudo python3 -m pip install 'maturin<0.12'
           maturin build -m columnq-cli/Cargo.toml -b bin --no-sdist --release -o dist \
             --target ${{ matrix.platform.target }} --manylinux ${{ matrix.platform.manylinux }} \
             --cargo-extra-args="--features=${{ matrix.platform.features }}"

--- a/.github/workflows/columnq_cli_release.yml
+++ b/.github/workflows/columnq_cli_release.yml
@@ -121,12 +121,12 @@ jobs:
       fail-fast: false
       matrix:
         platform: [
-          { manylinux: '2010', target: "x86_64-unknown-linux-musl", image_tag: "x86_64-musl", features: "simd,rustls" },
+#          { manylinux: '2010', target: "x86_64-unknown-linux-musl", image_tag: "x86_64-musl", features: "simd,rustls" },
           { manylinux: '2010', target: "x86_64-unknown-linux-musl", image_tag: "x86_64-musl", features: "simd,native-tls-vendored" },
           # { manylinux: '2010', target: "i686-unknown-linux-musl", image_tag: "i686-musl", features: "" },
-          { manylinux: '2014', target: "aarch64-unknown-linux-musl", image_tag: "aarch64-musl", features: "rustls" },
+#          { manylinux: '2014', target: "aarch64-unknown-linux-musl", image_tag: "aarch64-musl", features: "rustls" },
           { manylinux: '2014', target: "aarch64-unknown-linux-musl", image_tag: "aarch64-musl", features: "native-tls-vendored" },
-          { manylinux: '2014', target: "armv7-unknown-linux-musleabihf", image_tag: "armv7-musleabihf", features: "rustls" },
+#          { manylinux: '2014', target: "armv7-unknown-linux-musleabihf", image_tag: "armv7-musleabihf", features: "rustls" },
           { manylinux: '2014', target: "armv7-unknown-linux-musleabihf", image_tag: "armv7-musleabihf", features: "native-tls-vendored" },
         ]
     container:

--- a/.github/workflows/columnq_cli_release.yml
+++ b/.github/workflows/columnq_cli_release.yml
@@ -7,7 +7,7 @@ on:
       - 'columnq/**'
       - 'columnq-cli/**'
       - 'Cargo.lock'
-    branches: [ main, rustls ]
+    branches: [ main ]
     tags: [ 'columnq-cli-v*' ]
 
 env:

--- a/.github/workflows/roapi_http_release.yml
+++ b/.github/workflows/roapi_http_release.yml
@@ -122,12 +122,12 @@ jobs:
       fail-fast: false
       matrix:
         platform: [
-          { manylinux: '2010', target: "x86_64-unknown-linux-musl", image_tag: "x86_64-musl", features: "simd,rustls" },
+#          { manylinux: '2010', target: "x86_64-unknown-linux-musl", image_tag: "x86_64-musl", features: "simd,rustls" },
           { manylinux: '2010', target: "x86_64-unknown-linux-musl", image_tag: "x86_64-musl", features: "simd,native-tls-vendored" },
           # { manylinux: '2010', target: "i686-unknown-linux-musl", image_tag: "i686-musl", features: "" },
-          { manylinux: '2014', target: "aarch64-unknown-linux-musl", image_tag: "aarch64-musl", features: "rustls" },
+#          { manylinux: '2014', target: "aarch64-unknown-linux-musl", image_tag: "aarch64-musl", features: "rustls" },
           { manylinux: '2014', target: "aarch64-unknown-linux-musl", image_tag: "aarch64-musl", features: "native-tls-vendored" },
-          { manylinux: '2014', target: "armv7-unknown-linux-musleabihf", image_tag: "armv7-musleabihf", features: "rustls" },
+#          { manylinux: '2014', target: "armv7-unknown-linux-musleabihf", image_tag: "armv7-musleabihf", features: "rustls" },
           { manylinux: '2014', target: "armv7-unknown-linux-musleabihf", image_tag: "armv7-musleabihf", features: "native-tls-vendored" },
         ]
     container:

--- a/.github/workflows/roapi_http_release.yml
+++ b/.github/workflows/roapi_http_release.yml
@@ -122,13 +122,13 @@ jobs:
       fail-fast: false
       matrix:
         platform: [
-#          { manylinux: '2010', target: "x86_64-unknown-linux-musl", image_tag: "x86_64-musl", features: "simd,rustls" },
-          { manylinux: '2010', target: "x86_64-unknown-linux-musl", image_tag: "x86_64-musl", features: "simd,native-tls-vendored" },
+          { manylinux: '2010', target: "x86_64-unknown-linux-musl", image_tag: "x86_64-musl", features: "simd,rustls", upload: "true" },
+          { manylinux: '2010', target: "x86_64-unknown-linux-musl", image_tag: "x86_64-musl", features: "simd,native-tls-vendored", upload: "false" },
           # { manylinux: '2010', target: "i686-unknown-linux-musl", image_tag: "i686-musl", features: "" },
-#          { manylinux: '2014', target: "aarch64-unknown-linux-musl", image_tag: "aarch64-musl", features: "rustls" },
-          { manylinux: '2014', target: "aarch64-unknown-linux-musl", image_tag: "aarch64-musl", features: "native-tls-vendored" },
-#          { manylinux: '2014', target: "armv7-unknown-linux-musleabihf", image_tag: "armv7-musleabihf", features: "rustls" },
-          { manylinux: '2014', target: "armv7-unknown-linux-musleabihf", image_tag: "armv7-musleabihf", features: "native-tls-vendored" },
+          { manylinux: '2014', target: "aarch64-unknown-linux-musl", image_tag: "aarch64-musl", features: "rustls", upload: "true"},
+          { manylinux: '2014', target: "aarch64-unknown-linux-musl", image_tag: "aarch64-musl", features: "native-tls-vendored", upload: "false" },
+          { manylinux: '2014', target: "armv7-unknown-linux-musleabihf", image_tag: "armv7-musleabihf", features: "rustls", upload: "true" },
+          { manylinux: '2014', target: "armv7-unknown-linux-musleabihf", image_tag: "armv7-musleabihf", features: "native-tls-vendored", upload: "false" },
         ]
     container:
       image: docker://messense/rust-musl-cross:${{ matrix.platform.image_tag }}
@@ -152,14 +152,16 @@ jobs:
             --cargo-extra-args="--no-default-features --features=${{ matrix.platform.features }}"
       - name: Upload wheels
         uses: actions/upload-artifact@v2
+        if: "matrix.platform.upload == 'true'"
         with:
           name: wheels
           path: dist
       - name: Archive binary
+        if: "matrix.platform.upload == 'true'"
         run: tar czvf target/release/roapi-http.tar.gz -C target/${{ matrix.platform.target }}/release roapi-http
       - name: Upload binary to GitHub Release
         uses: svenstaro/upload-release-action@v2
-        if: "startsWith(github.ref, 'refs/tags/')"
+        if: "startsWith(github.ref, 'refs/tags/') && matrix.platform.upload == 'true'"
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           asset_name: roapi-http-${{ matrix.platform.target }}.tar.gz

--- a/.github/workflows/roapi_http_release.yml
+++ b/.github/workflows/roapi_http_release.yml
@@ -122,10 +122,13 @@ jobs:
       fail-fast: false
       matrix:
         platform: [
-          { manylinux: '2010', target: "x86_64-unknown-linux-musl", image_tag: "x86_64-musl", features: "simd" },
+          { manylinux: '2010', target: "x86_64-unknown-linux-musl", image_tag: "x86_64-musl", features: "simd,rustls" },
+          { manylinux: '2010', target: "x86_64-unknown-linux-musl", image_tag: "x86_64-musl", features: "simd,native-tls-vendored" },
           # { manylinux: '2010', target: "i686-unknown-linux-musl", image_tag: "i686-musl", features: "" },
-          { manylinux: '2014', target: "aarch64-unknown-linux-musl", image_tag: "aarch64-musl", features: "" },
-          { manylinux: '2014', target: "armv7-unknown-linux-musleabihf", image_tag: "armv7-musleabihf", features: "" },
+          { manylinux: '2014', target: "aarch64-unknown-linux-musl", image_tag: "aarch64-musl", features: "rustls" },
+          { manylinux: '2014', target: "aarch64-unknown-linux-musl", image_tag: "aarch64-musl", features: "native-tls-vendored" },
+          { manylinux: '2014', target: "armv7-unknown-linux-musleabihf", image_tag: "armv7-musleabihf", features: "rustls" },
+          { manylinux: '2014', target: "armv7-unknown-linux-musleabihf", image_tag: "armv7-musleabihf", features: "native-tls-vendored" },
         ]
     container:
       image: docker://messense/rust-musl-cross:${{ matrix.platform.image_tag }}
@@ -146,7 +149,7 @@ jobs:
           sudo python3 -m pip install 'maturin<0.12'
           maturin build -m roapi-http/Cargo.toml -b bin --no-sdist --release -o dist \
             --target ${{ matrix.platform.target }} --manylinux ${{ matrix.platform.manylinux }} \
-            --cargo-extra-args="--features=${{ matrix.platform.features }}"
+            --cargo-extra-args="--no-default-features --features=${{ matrix.platform.features }}"
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/roapi_http_release.yml
+++ b/.github/workflows/roapi_http_release.yml
@@ -7,7 +7,7 @@ on:
       - 'columnq/**'
       - 'roapi-http/**'
       - 'Cargo.lock'
-    branches: [ main, rustls ]
+    branches: [ main ]
     tags: [ 'roapi-http-v*' ]
 
 env:

--- a/.github/workflows/roapi_http_release.yml
+++ b/.github/workflows/roapi_http_release.yml
@@ -3,10 +3,11 @@ name: roapi-http release
 on:
   push:
     paths:
+      - '.github/workflows/roapi_http_release.yml'
       - 'columnq/**'
       - 'roapi-http/**'
       - 'Cargo.lock'
-    branches: [ main ]
+    branches: [ main, rustls ]
     tags: [ 'roapi-http-v*' ]
 
 env:
@@ -118,6 +119,7 @@ jobs:
     needs: validate-release-tag
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         platform: [
           { manylinux: '2010', target: "x86_64-unknown-linux-musl", image_tag: "x86_64-musl", features: "simd" },
@@ -126,7 +128,7 @@ jobs:
           { manylinux: '2014', target: "armv7-unknown-linux-musleabihf", image_tag: "armv7-musleabihf", features: "" },
         ]
     container:
-      image: docker://benfred/rust-musl-cross:${{ matrix.platform.image_tag }}
+      image: docker://messense/rust-musl-cross:${{ matrix.platform.image_tag }}
       env:
         RUSTUP_HOME: /root/.rustup
         CARGO_HOME: /root/.cargo
@@ -141,8 +143,10 @@ jobs:
           rustup default nightly-${{ env.RUST_TC_NIGHTLY_VER }}
       - name: Build Wheels
         run: |
-          pip3 install 'maturin<0.12'
-          maturin build -m roapi-http/Cargo.toml -b bin --no-sdist --release -o dist --target ${{ matrix.platform.target }} --manylinux ${{ matrix.platform.manylinux }} --cargo-extra-args="--features=${{ matrix.platform.features }}"
+          sudo python3 -m pip install maturin
+          maturin build -m roapi-http/Cargo.toml -b bin --no-sdist --release -o dist \
+            --target ${{ matrix.platform.target }} --manylinux ${{ matrix.platform.manylinux }} \
+            --cargo-extra-args="--features=${{ matrix.platform.features }}"
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/roapi_http_release.yml
+++ b/.github/workflows/roapi_http_release.yml
@@ -143,7 +143,7 @@ jobs:
           rustup default nightly-${{ env.RUST_TC_NIGHTLY_VER }}
       - name: Build Wheels
         run: |
-          sudo python3 -m pip install maturin
+          sudo python3 -m pip install 'maturin<0.12'
           maturin build -m roapi-http/Cargo.toml -b bin --no-sdist --release -o dist \
             --target ${{ matrix.platform.target }} --manylinux ${{ matrix.platform.manylinux }} \
             --cargo-extra-args="--features=${{ matrix.platform.features }}"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -551,6 +551,8 @@ dependencies = [
  "deltalake",
  "futures",
  "graphql-parser",
+ "hyper-rustls",
+ "hyper-tls",
  "lazy_static",
  "log",
  "pretty_assertions",
@@ -972,6 +974,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1278,6 +1295,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
+
+[[package]]
 name = "idna"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1579,6 +1609,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48ba9f7719b5a0f42f338907614285fb5fd70e53858141f69898a1fb7203b24d"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "nibble_vec"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1708,10 +1756,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "openssl"
+version = "0.10.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d9facdb76fec0b73c406f125d44d86fdad818d66fef0531eec9233ca425ff4a"
+dependencies = [
+ "bitflags",
+ "cfg-if 1.0.0",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-sys",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
+
+[[package]]
+name = "openssl-src"
+version = "111.16.0+1.1.1l"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ab2173f69416cf3ec12debb5823d244127d23a9b127d5a5189aa97c5fa2859f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69df2d8dfc6ce3aaf44b40dec6f487d5a886516cf6879c49e98e0710f310a058"
+dependencies = [
+ "autocfg",
+ "cc",
+ "libc",
+ "openssl-src",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "ordered-float"
@@ -1853,6 +1938,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c9b1041b4387893b91ee6746cddfc28516aff326a3519fb2adf820932c5e6cb"
 
 [[package]]
 name = "ppv-lite86"
@@ -2082,11 +2173,13 @@ dependencies = [
  "http-body",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "ipnet",
  "js-sys",
  "lazy_static",
  "log",
  "mime",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "rustls",
@@ -2094,6 +2187,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded 0.7.0",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "url",
  "wasm-bindgen",
@@ -2153,6 +2247,7 @@ dependencies = [
  "http",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "lazy_static",
  "log",
  "rusoto_credential 0.46.0",
@@ -2178,6 +2273,7 @@ dependencies = [
  "http",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "lazy_static",
  "log",
  "rusoto_credential 0.47.0",
@@ -2792,6 +2888,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "rand 0.8.3",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2943,6 +3053,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -3107,6 +3227,12 @@ dependencies = [
  "getrandom",
  "serde",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vec_map"
@@ -3306,6 +3432,7 @@ dependencies = [
  "http",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "log",
  "percent-encoding",
  "rustls",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,7 +201,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded 0.7.0",
  "smallvec",
- "socket2",
+ "socket2 0.3.19",
  "time 0.2.25",
  "url",
 ]
@@ -972,21 +972,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1253,9 +1238,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.4"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8e946c2b1349055e0b72ae281b238baf1a3ea7307c7e9f9d64673bdd9c26ac7"
+checksum = "8bf09f61b52cfcf4c00de50df88ae423d6c02354e385a86341133b5338630ad1"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1268,7 +1253,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project",
- "socket2",
+ "socket2 0.4.2",
  "tokio",
  "tower-service",
  "tracing",
@@ -1290,19 +1275,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "webpki",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes",
- "hyper",
- "native-tls",
- "tokio",
- "tokio-native-tls",
 ]
 
 [[package]]
@@ -1582,7 +1554,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
 dependencies = [
- "socket2",
+ "socket2 0.3.19",
  "winapi",
 ]
 
@@ -1604,24 +1576,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8d96b2e1c8da3957d58100b09f102c6d9cfdfced01b7ec5a8974044bb09dbd4"
-dependencies = [
- "lazy_static",
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
 ]
 
 [[package]]
@@ -1754,37 +1708,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
-name = "openssl"
-version = "0.10.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a61075b62a23fef5a29815de7536d940aa35ce96d18ce0cc5076272db678a577"
-dependencies = [
- "bitflags",
- "cfg-if 1.0.0",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-sys",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.61"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "313752393519e876837e09e1fa183ddef0be7735868dced3196f4472d536277f"
-dependencies = [
- "autocfg",
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "ordered-float"
@@ -1926,12 +1853,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "pkg-config"
-version = "0.3.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
 name = "ppv-lite86"
@@ -2148,9 +2069,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.2"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf12057f289428dbf5c591c74bf10392e4a8003f993405a902f20117019022d4"
+checksum = "246e9f61b9bb77df069a947682be06e31ac43ea37862e244a69f177694ea6d22"
 dependencies = [
  "base64",
  "bytes",
@@ -2160,24 +2081,25 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "hyper-tls",
+ "hyper-rustls",
  "ipnet",
  "js-sys",
  "lazy_static",
  "log",
  "mime",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
  "serde",
  "serde_json",
  "serde_urlencoded 0.7.0",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
  "winreg",
 ]
 
@@ -2230,7 +2152,7 @@ dependencies = [
  "futures",
  "http",
  "hyper",
- "hyper-tls",
+ "hyper-rustls",
  "lazy_static",
  "log",
  "rusoto_credential 0.46.0",
@@ -2255,7 +2177,7 @@ dependencies = [
  "futures",
  "http",
  "hyper",
- "hyper-tls",
+ "hyper-rustls",
  "lazy_static",
  "log",
  "rusoto_credential 0.47.0",
@@ -2724,6 +2646,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dc90fe6c7be1a323296982db1836d1ea9e47b6839496dde9a541bc496df3516"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2857,20 +2789,6 @@ checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
 dependencies = [
  "rand 0.4.6",
  "remove_dir_all",
-]
-
-[[package]]
-name = "tempfile"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
-dependencies = [
- "cfg-if 1.0.0",
- "libc",
- "rand 0.8.3",
- "redox_syscall",
- "remove_dir_all",
- "winapi",
 ]
 
 [[package]]
@@ -3025,16 +2943,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]
@@ -3201,12 +3109,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "vcpkg"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b00bca6106a5e23f3eee943593759b7fcddb00554332e856d990c893966879fb"
-
-[[package]]
 name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3326,6 +3228,15 @@ checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
 dependencies = [
  "ring",
  "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aabe153544e473b775453675851ecc86863d2a81d786d741f6b76778f2a48940"
+dependencies = [
+ "webpki",
 ]
 
 [[package]]

--- a/columnq-cli/Cargo.toml
+++ b/columnq-cli/Cargo.toml
@@ -24,6 +24,9 @@ clap = { version = ">=3.0.0-beta.2,<4", features = ["color"] }
 dirs = { version = "3" }
 
 [features]
+default = ["rustls"]
+rustls = ["columnq/rustls"]
+native-tls-vendored = ["columnq/native-tls-vendored"]
 simd = ["columnq/simd"]
 
 [dev-dependencies]

--- a/columnq-cli/Cargo.toml
+++ b/columnq-cli/Cargo.toml
@@ -24,7 +24,7 @@ clap = { version = ">=3.0.0-beta.2,<4", features = ["color"] }
 dirs = { version = "3" }
 
 [features]
-default = ["native-tls-vendored"]
+default = ["rustls"]
 rustls = ["columnq/rustls"]
 native-tls-vendored = ["columnq/native-tls-vendored"]
 simd = ["columnq/simd"]

--- a/columnq-cli/Cargo.toml
+++ b/columnq-cli/Cargo.toml
@@ -12,7 +12,7 @@ name = "columnq"
 path = "src/main.rs"
 
 [dependencies]
-columnq = { path = "../columnq", version = "0" }
+columnq = { path = "../columnq", version = "0", default-features = false }
 
 serde_json = "*"
 log = "0"

--- a/columnq-cli/Cargo.toml
+++ b/columnq-cli/Cargo.toml
@@ -24,7 +24,7 @@ clap = { version = ">=3.0.0-beta.2,<4", features = ["color"] }
 dirs = { version = "3" }
 
 [features]
-default = ["rustls"]
+default = ["native-tls-vendored"]
 rustls = ["columnq/rustls"]
 native-tls-vendored = ["columnq/native-tls-vendored"]
 simd = ["columnq/simd"]

--- a/columnq/Cargo.toml
+++ b/columnq/Cargo.toml
@@ -49,7 +49,7 @@ tempdir = "0"
 pretty_assertions = "*"
 
 [features]
-default = ["rustls"]
+default = ["native-tls-vendored"]
 rustls = ["reqwest/rustls-tls", "rusoto_core/rustls", "rusoto_core/rustls", "rusoto_sts/rustls", "deltalake/s3-rustls", "yup-oauth2/hyper-rustls"]
 native-tls-vendored = ["reqwest/native-tls-vendored", "hyper-tls/vendored", "rusoto_core/native-tls", "rusoto_s3/native-tls", "rusoto_sts/native-tls", "deltalake/s3", "yup-oauth2/hyper-tls"]
 simd = ["datafusion/simd"]

--- a/columnq/Cargo.toml
+++ b/columnq/Cargo.toml
@@ -49,7 +49,7 @@ tempdir = "0"
 pretty_assertions = "*"
 
 [features]
-default = []
+default = ["rustls"]
 rustls = ["reqwest/rustls-tls", "rusoto_core/rustls", "rusoto_core/rustls", "rusoto_sts/rustls", "deltalake/s3-rustls", "yup-oauth2/hyper-rustls"]
 native-tls-vendored = ["reqwest/native-tls-vendored", "hyper-tls/vendored", "rusoto_core/native-tls", "rusoto_s3/native-tls", "rusoto_sts/native-tls", "deltalake/s3", "yup-oauth2/hyper-tls"]
 simd = ["datafusion/simd"]

--- a/columnq/Cargo.toml
+++ b/columnq/Cargo.toml
@@ -36,8 +36,8 @@ rusoto_core = { version = "0.47", default-features = false }
 rusoto_s3 = { version = "0.47", default-features = false }
 rusoto_credential = { version = "0.47" }
 rusoto_sts = { version = "0.47", default-features = false }
-hyper-tls = { version = "0.5.0", default-features = false, features = ["vendored"], optional = true}
-hyper-rustls = { version = "0.22.1", default-features = false, optional = true}
+hyper-tls = { version = "0.5.0", default-features = false, features = ["vendored"], optional = true }
+hyper-rustls = { version = "0.22.1", default-features = false, optional = true }
 
 
 deltalake = { version = "0", default-features = false, features = ["datafusion-ext"] }

--- a/columnq/Cargo.toml
+++ b/columnq/Cargo.toml
@@ -26,19 +26,19 @@ serde_derive = "1"
 serde = "1"
 uriparse = "0"
 bytes = { version = "1" }
-reqwest = { version = "0.11", features = ["blocking", "json"] }
+reqwest = { version = "0.11", default-features = false, features = ["blocking", "json", "rustls-tls"] }
 
 tokio = "1"
 futures = "0.3"
 
 # S3
-rusoto_core = { version = "0.47" }
-rusoto_s3 = { version = "0.47" }
+rusoto_core = { version = "0.47", default-features = false, features=["rustls"] }
+rusoto_s3 = { version = "0.47", default-features = false, features=["rustls"]}
 rusoto_credential = { version = "0.47" }
-rusoto_sts = { version = "0.47" }
+rusoto_sts = { version = "0.47", default-features = false, features=["rustls"] }
 
 
-deltalake = { version = "0", features = ["s3", "datafusion-ext"] }
+deltalake = { version = "0", default-features = false, features = ["s3-rustls", "datafusion-ext"] }
 
 [dev-dependencies]
 anyhow = "1"

--- a/columnq/Cargo.toml
+++ b/columnq/Cargo.toml
@@ -49,7 +49,7 @@ tempdir = "0"
 pretty_assertions = "*"
 
 [features]
-default = ["native-tls-vendored"]
+default = ["rustls"]
 rustls = ["reqwest/rustls-tls", "rusoto_core/rustls", "rusoto_core/rustls", "rusoto_sts/rustls", "deltalake/s3-rustls", "yup-oauth2/hyper-rustls"]
 native-tls-vendored = ["reqwest/native-tls-vendored", "hyper-tls/vendored", "rusoto_core/native-tls", "rusoto_s3/native-tls", "rusoto_sts/native-tls", "deltalake/s3", "yup-oauth2/hyper-tls"]
 simd = ["datafusion/simd"]

--- a/columnq/Cargo.toml
+++ b/columnq/Cargo.toml
@@ -19,26 +19,28 @@ regex = "1"
 lazy_static = "1"
 graphql-parser = "0"
 sqlparser = "0.10"
-yup-oauth2 = "5"
+yup-oauth2 = { version = "5.1", default-features = false }
 thiserror = "1"
 serde_json = "1"
 serde_derive = "1"
 serde = "1"
 uriparse = "0"
 bytes = { version = "1" }
-reqwest = { version = "0.11", default-features = false, features = ["blocking", "json", "rustls-tls"] }
+reqwest = { version = "0.11", default-features = false, features = ["blocking", "json"] }
 
 tokio = "1"
 futures = "0.3"
 
 # S3
-rusoto_core = { version = "0.47", default-features = false, features=["rustls"] }
-rusoto_s3 = { version = "0.47", default-features = false, features=["rustls"]}
+rusoto_core = { version = "0.47", default-features = false }
+rusoto_s3 = { version = "0.47", default-features = false }
 rusoto_credential = { version = "0.47" }
-rusoto_sts = { version = "0.47", default-features = false, features=["rustls"] }
+rusoto_sts = { version = "0.47", default-features = false }
+hyper-tls = { version = "0.5.0", default-features = false, features = ["vendored"], optional = true}
+hyper-rustls = { version = "0.22.1", default-features = false, optional = true}
 
 
-deltalake = { version = "0", default-features = false, features = ["s3-rustls", "datafusion-ext"] }
+deltalake = { version = "0", default-features = false, features = ["datafusion-ext"] }
 
 [dev-dependencies]
 anyhow = "1"
@@ -47,4 +49,7 @@ tempdir = "0"
 pretty_assertions = "*"
 
 [features]
+default = []
+rustls = ["reqwest/rustls-tls", "rusoto_core/rustls", "rusoto_core/rustls", "rusoto_sts/rustls", "deltalake/s3-rustls", "yup-oauth2/hyper-rustls"]
+native-tls-vendored = ["reqwest/native-tls-vendored", "hyper-tls/vendored", "rusoto_core/native-tls", "rusoto_s3/native-tls", "rusoto_sts/native-tls", "deltalake/s3", "yup-oauth2/hyper-tls"]
 simd = ["datafusion/simd"]

--- a/roapi-http/Cargo.toml
+++ b/roapi-http/Cargo.toml
@@ -35,7 +35,7 @@ thiserror = "1"
 anyhow = "1"
 
 [features]
-default = ["native-tls-vendored"]
+default = ["rustls"]
 rustls = ["columnq/rustls"]
 native-tls-vendored = ["columnq/native-tls-vendored"]
 simd = ["columnq/simd"]

--- a/roapi-http/Cargo.toml
+++ b/roapi-http/Cargo.toml
@@ -15,7 +15,7 @@ name = "roapi-http"
 path = "src/main.rs"
 
 [dependencies]
-columnq = { path = "../columnq", version = "0", default-features = false}
+columnq = { path = "../columnq", version = "0", default-features = false }
 
 # all actix dependencies are patched to use git source until actix-web 4.x lands
 actix-web = "4.0.0-beta.4"

--- a/roapi-http/Cargo.toml
+++ b/roapi-http/Cargo.toml
@@ -15,7 +15,7 @@ name = "roapi-http"
 path = "src/main.rs"
 
 [dependencies]
-columnq = { path = "../columnq", version = "0" }
+columnq = { path = "../columnq", version = "0", default-features = false}
 
 # all actix dependencies are patched to use git source until actix-web 4.x lands
 actix-web = "4.0.0-beta.4"

--- a/roapi-http/Cargo.toml
+++ b/roapi-http/Cargo.toml
@@ -35,6 +35,9 @@ thiserror = "1"
 anyhow = "1"
 
 [features]
+default = ["rustls"]
+rustls = ["columnq/rustls"]
+native-tls-vendored = ["columnq/native-tls-vendored"]
 simd = ["columnq/simd"]
 
 [dev-dependencies]

--- a/roapi-http/Cargo.toml
+++ b/roapi-http/Cargo.toml
@@ -35,7 +35,7 @@ thiserror = "1"
 anyhow = "1"
 
 [features]
-default = ["rustls"]
+default = ["native-tls-vendored"]
 rustls = ["columnq/rustls"]
 native-tls-vendored = ["columnq/native-tls-vendored"]
 simd = ["columnq/simd"]


### PR DESCRIPTION
The upgrade that came with the SIMD build in the Dockerfile #81, broke the `columnq` and `roapi-http` builds. I tried fixing this in multiple ways but in the end upgrading the container to a more recent version and using rustls instead of native-tls (openssl) seems to work. I am not sure if my solution is acceptable, but I am not sure how to fix it otherwise.

I tried combining this with #31 but I only could get the x86_64 build to work. 