### PR TITLE
Docker image: install ca-certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN RUSTFLAGS='-C target-cpu=skylake' \
 FROM debian:bullseye-slim
 LABEL org.opencontainers.image.source https://github.com/roapi/roapi
 
-RUN apt-get update && apt-get install -y libssl-dev && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y libssl-dev ca-certificates && rm -rf /var/lib/apt/lists/*
 COPY test_data /test_data
 COPY --from=builder /usr/local/cargo/bin/roapi-http /usr/local/bin/roapi-http
 


### PR DESCRIPTION
This PR installs the package "ca-certificates" in the Docker image

Fixes #103 

Thanks