### PR TITLE
Make batch size configurable 

### DIFF
--- a/columnq/src/table/csv.rs
+++ b/columnq/src/table/csv.rs
@@ -21,7 +21,7 @@ pub async fn to_mem_table(
     let delimiter = opt.delimiter;
     let projection = opt.projection.as_ref();
 
-    let batch_size = 1024;
+    let batch_size = t.batch_size;
 
     debug!("inferring csv table schema...");
     let schema_ref: arrow::datatypes::SchemaRef = match &t.schema {

--- a/columnq/src/table/json.rs
+++ b/columnq/src/table/json.rs
@@ -104,8 +104,7 @@ fn json_vec_to_partition(
 pub async fn to_mem_table(
     t: &TableSource,
 ) -> Result<datafusion::datasource::MemTable, ColumnQError> {
-    // TODO: make batch size configurable
-    let batch_size = 1024;
+    let batch_size = t.batch_size;
     let array_encoded = match &t.option {
         Some(TableLoadOption::json { array_encoded, .. }) => array_encoded.unwrap_or(false),
         _ => false,

--- a/columnq/src/table/ndjson.rs
+++ b/columnq/src/table/ndjson.rs
@@ -11,8 +11,7 @@ use crate::table::TableSource;
 pub async fn to_mem_table(
     t: &TableSource,
 ) -> Result<datafusion::datasource::MemTable, ColumnQError> {
-    // TODO: make batch size configurable
-    let batch_size = 1024;
+    let batch_size = t.batch_size;
 
     let schema_ref: SchemaRef = match &t.schema {
         Some(table_schema) => Arc::new(table_schema.into()),

--- a/columnq/src/table/parquet.rs
+++ b/columnq/src/table/parquet.rs
@@ -32,8 +32,7 @@ pub async fn to_datafusion_table(t: &TableSource) -> Result<Arc<dyn TableProvide
 }
 
 pub async fn to_mem_table(t: &TableSource) -> Result<Arc<dyn TableProvider>, ColumnQError> {
-    // TODO: make batch size configurable
-    let batch_size = 1024;
+    let batch_size = t.batch_size;
 
     let mut schema: Option<Schema> = None;
 


### PR DESCRIPTION
Addresses https://github.com/roapi/roapi/issues/19

Extracted batch_size into TableLoadOption for the relevant table formats.

I haven't added more tests to verify batch_size works. Not 100% sure the best way to test the batch size config, tbh.  


