### PR TITLE
Wrap reader as bufreader for file json and ndjson

### DIFF
--- a/columnq/src/table/json.rs
+++ b/columnq/src/table/json.rs
@@ -1,4 +1,4 @@
-use std::io::Read;
+use std::io::{BufReader, Read};
 use std::sync::Arc;
 
 use datafusion::arrow;
@@ -10,7 +10,8 @@ use crate::error::ColumnQError;
 use crate::table::{TableLoadOption, TableSchema, TableSource};
 
 fn json_value_from_reader<R: Read>(r: R) -> Result<Value, ColumnQError> {
-    serde_json::from_reader(r).map_err(ColumnQError::json_parse)
+    let reader = BufReader::new(r);
+    serde_json::from_reader(reader).map_err(ColumnQError::json_parse)
 }
 
 fn json_partition_to_vec(

--- a/columnq/src/table/ndjson.rs
+++ b/columnq/src/table/ndjson.rs
@@ -1,4 +1,4 @@
-use std::io::BufReader;
+use std::io::{BufReader, Read};
 use std::sync::Arc;
 
 use datafusion::arrow::datatypes::{Schema, SchemaRef};
@@ -8,20 +8,33 @@ use datafusion::arrow::record_batch::RecordBatch;
 use crate::error::ColumnQError;
 use crate::table::TableSource;
 
+fn json_schema_from_reader<R: Read>(r: R) -> Result<Schema, ColumnQError> {
+    let mut reader = BufReader::new(r);
+    Ok(infer_json_schema(&mut reader, None)?)
+}
+
+fn decode_json_from_reader<R: Read>(r: R, schema_ref: SchemaRef, batch_size: usize) -> Result<Vec<RecordBatch>, ColumnQError> {
+    let decoder = Decoder::new(schema_ref, batch_size, None);
+    let mut reader = BufReader::new(r);
+    let mut value_reader = ValueIter::new(&mut reader, None);
+    let mut batches = vec![];
+    while let Some(batch) = decoder.next_batch(&mut value_reader)? {
+        batches.push(batch);
+    }
+    Ok(batches)
+}
+
 pub async fn to_mem_table(
     t: &TableSource,
 ) -> Result<datafusion::datasource::MemTable, ColumnQError> {
     let batch_size = t.batch_size;
-
+    
     let schema_ref: SchemaRef = match &t.schema {
         Some(table_schema) => Arc::new(table_schema.into()),
         // infer schema from data if not provided by user
         None => {
             let inferred_schema: Vec<Schema> =
-                partitions_from_table_source!(t, |reader| -> Result<Schema, ColumnQError> {
-                    let mut reader = BufReader::new(reader);
-                    Ok(infer_json_schema(&mut reader, None)?)
-                })?;
+                partitions_from_table_source!(t, json_schema_from_reader)?;
             if inferred_schema.is_empty() {
                 return Err(ColumnQError::LoadJson("failed to load schema".to_string()));
             }
@@ -29,18 +42,8 @@ pub async fn to_mem_table(
         }
     };
 
-    let decoder = Decoder::new(schema_ref.clone(), batch_size, None);
-
-    let partitions: Vec<Vec<RecordBatch>> =
-        partitions_from_table_source!(t, |reader| -> Result<Vec<RecordBatch>, ColumnQError> {
-            let mut reader = BufReader::new(reader);
-            let mut value_reader = ValueIter::new(&mut reader, None);
-            let mut batches = vec![];
-            while let Some(batch) = decoder.next_batch(&mut value_reader)? {
-                batches.push(batch);
-            }
-            Ok(batches)
-        })?;
+    let partitions: Vec<Vec<RecordBatch>> = 
+            partitions_from_table_source!(t, |reader| decode_json_from_reader(reader, schema_ref.clone(), batch_size))?;
 
     Ok(datafusion::datasource::MemTable::try_new(
         schema_ref, partitions,

--- a/columnq/src/table/ndjson.rs
+++ b/columnq/src/table/ndjson.rs
@@ -28,7 +28,7 @@ pub async fn to_mem_table(
     t: &TableSource,
 ) -> Result<datafusion::datasource::MemTable, ColumnQError> {
     let batch_size = t.batch_size;
-    
+
     let schema_ref: SchemaRef = match &t.schema {
         Some(table_schema) => Arc::new(table_schema.into()),
         // infer schema from data if not provided by user


### PR DESCRIPTION
Addresses Issue 20 https://github.com/roapi/roapi/issues/20

I wasn't sure about the coding standard - when is it appropriate to reference type explicitly versus a use statement. eg `std::io::Cursor` vs `use std::io::Cursor`. I have tended to the use.