### PR TITLE
Fix cargo install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ pre-built binaries for each platform. Pre-built docker images are also available
 ### Install from source
 
 ```bash
-cargo install --locked --git https://github.com/roapi/roapi --branch main --bin roapi-http
+cargo install --locked --git https://github.com/roapi/roapi --branch main --bins roapi-http
 ```
 
 


### PR DESCRIPTION
Current suggested usage causes this error:

```
cargo install --locked --git https://github.com/roapi/roapi --branch main --bin roapi-http                                                        

    Updating git repository `https://github.com/roapi/roapi`
error: multiple packages with binaries found: columnq-cli, roapi-http. When installing a git repository, cargo will always search the entire repo for any Cargo.toml. Please specify which to install.
```