### PR TITLE
change host from HOST env var

### DIFF
--- a/roapi-http/src/startup.rs
+++ b/roapi-http/src/startup.rs
@@ -17,9 +17,9 @@ pub struct Application {
 
 impl Application {
     pub async fn build(config: Config) -> anyhow::Result<Self> {
-        let default_host = "127.0.0.1";
+        let default_host = std::env::var("HOST").unwrap_or_else(|_| "127.0.0.1".to_string());
         let default_port = std::env::var("PORT").unwrap_or_else(|_| "8080".to_string());
-        let default_addr = default_host.to_string() + ":" + &default_port.to_string();
+        let default_addr = [default_host.to_string(), default_port.to_string()].join(":");
         let addr = (config.addr)
             .clone()
             .unwrap_or_else(|| default_addr.to_string());


### PR DESCRIPTION
I should have done this in the previous PR. I think I'm getting closer to getting ROAPI to work fairly easily on Heroku, but some other examples I've seen want to be able to set the host to `0.0.0.0` rather than `127.0.0.1`. As a reminder, I still can't use the config file here, because Heroku sets the port dynamically.