### PR TITLE
dep: replace `tempdir` to `tempfile`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -587,7 +587,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sqlparser 0.23.0",
- "tempdir",
+ "tempfile",
  "thiserror",
  "tokio",
  "uriparse",
@@ -909,7 +909,7 @@ dependencies = [
  "parquet",
  "paste",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand",
  "smallvec",
  "sqlparser 0.23.0",
  "tempfile",
@@ -980,7 +980,7 @@ dependencies = [
  "md-5 0.10.5",
  "ordered-float 3.1.0",
  "paste",
- "rand 0.8.5",
+ "rand",
  "regex",
  "sha2 0.10.6",
  "unicode-segmentation",
@@ -995,7 +995,7 @@ dependencies = [
  "arrow",
  "datafusion-common",
  "paste",
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -1415,12 +1415,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "funty"
@@ -2244,7 +2238,7 @@ dependencies = [
  "lexical",
  "num-bigint 0.4.3",
  "num-traits",
- "rand 0.8.5",
+ "rand",
  "regex",
  "rust_decimal",
  "saturating",
@@ -2439,7 +2433,7 @@ dependencies = [
  "parking_lot",
  "percent-encoding",
  "quick-xml",
- "rand 0.8.5",
+ "rand",
  "reqwest",
  "ring",
  "serde",
@@ -2618,7 +2612,7 @@ dependencies = [
  "num",
  "num-bigint 0.4.3",
  "parquet-format",
- "rand 0.8.5",
+ "rand",
  "seq-macro",
  "snap",
  "thrift",
@@ -2761,7 +2755,7 @@ dependencies = [
  "hmac 0.12.1",
  "md-5 0.10.5",
  "memchr",
- "rand 0.8.5",
+ "rand",
  "sha2 0.10.6",
  "stringprep",
 ]
@@ -2878,26 +2872,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -2907,23 +2888,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
+ "rand_core",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -2956,15 +2922,6 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
  "num_cpus",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -3969,16 +3926,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
-name = "tempdir"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
-dependencies = [
- "rand 0.4.6",
- "remove_dir_all",
-]
-
-[[package]]
 name = "tempfile"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4348,7 +4295,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.8.5",
+ "rand",
  "static_assertions",
 ]
 

--- a/columnq/Cargo.toml
+++ b/columnq/Cargo.toml
@@ -58,7 +58,7 @@ optional = true
 [dev-dependencies]
 anyhow = "1"
 serde_yaml = "0.8"
-tempdir = "0"
+tempfile = "3.3.0"
 pretty_assertions = "*"
 dotenv = "*"
 

--- a/columnq/src/table/arrow_ipc_file.rs
+++ b/columnq/src/table/arrow_ipc_file.rs
@@ -52,13 +52,16 @@ mod tests {
     use datafusion::datasource::TableProvider;
     use datafusion::prelude::SessionContext;
     use std::fs;
+    use tempfile::Builder;
 
     use crate::table::TableLoadOption;
     use crate::test_util::*;
 
     #[tokio::test]
     async fn load_partitions() -> anyhow::Result<()> {
-        let tmp_dir = tempdir::TempDir::new("columnq.test.arrows_partitions")?;
+        let tmp_dir = Builder::new()
+            .prefix("columnq.test.arrows_partitions")
+            .tempdir()?;
         let tmp_dir_path = tmp_dir.path();
 
         let source_path = test_data_path("uk_cities_with_headers.arrow");

--- a/columnq/src/table/arrow_ipc_stream.rs
+++ b/columnq/src/table/arrow_ipc_stream.rs
@@ -52,13 +52,16 @@ mod tests {
     use datafusion::datasource::TableProvider;
     use datafusion::prelude::SessionContext;
     use std::fs;
+    use tempfile::Builder;
 
     use crate::table::TableLoadOption;
     use crate::test_util::*;
 
     #[tokio::test]
     async fn load_partitions() -> anyhow::Result<()> {
-        let tmp_dir = tempdir::TempDir::new("columnq.test.arrows_partitions")?;
+        let tmp_dir = Builder::new()
+            .prefix("columnq.test.arrows_partitions")
+            .tempdir()?;
         let tmp_dir_path = tmp_dir.path();
 
         let source_path = test_data_path("uk_cities_with_headers.arrows");

--- a/columnq/src/table/csv.rs
+++ b/columnq/src/table/csv.rs
@@ -77,13 +77,16 @@ mod tests {
     use datafusion::datasource::TableProvider;
     use datafusion::prelude::SessionContext;
     use std::fs;
+    use tempfile::Builder;
 
     use crate::table::{TableIoSource, TableLoadOption};
     use crate::test_util::*;
 
     #[tokio::test]
     async fn load_partitions() -> anyhow::Result<()> {
-        let tmp_dir = tempdir::TempDir::new("columnq.test.csv_partitions")?;
+        let tmp_dir = Builder::new()
+            .prefix("columnq.test.csv_partitions")
+            .tempdir()?;
         let tmp_dir_path = tmp_dir.path();
 
         let source_path = test_data_path("uk_cities_with_headers.csv");

--- a/columnq/src/table/parquet.rs
+++ b/columnq/src/table/parquet.rs
@@ -99,6 +99,7 @@ pub async fn to_mem_table(t: &TableSource) -> Result<Arc<dyn TableProvider>, Col
 mod tests {
     use super::*;
     use std::fs;
+    use tempfile::Builder;
 
     use crate::table::TableLoadOption;
     use crate::test_util::*;
@@ -153,7 +154,9 @@ mod tests {
 
     #[tokio::test]
     async fn load_partitions() -> anyhow::Result<()> {
-        let tmp_dir = tempdir::TempDir::new("columnq.test.parquet_partitions")?;
+        let tmp_dir = Builder::new()
+            .prefix("columnq.test.parquet_partitions")
+            .tempdir()?;
         let tmp_dir_path = tmp_dir.path();
 
         let source_path = test_data_path("blogs.parquet");


### PR DESCRIPTION
Just removed `tempdir` because of deprecation. Instead added `tempfile` crate that had taken over `tempdir`.