### PR TITLE
Implementation of response format config (#212)

### DIFF
--- a/columnq/src/encoding/mod.rs
+++ b/columnq/src/encoding/mod.rs
@@ -1,6 +1,9 @@
+use serde_derive::Deserialize;
 use std::convert::TryFrom;
 
+#[derive(Deserialize, Default, Clone, Copy)]
 pub enum ContentType {
+    #[default]
     Json,
     Csv,
     ArrowFile,

--- a/roapi/src/api/graphql.rs
+++ b/roapi/src/api/graphql.rs
@@ -14,7 +14,8 @@ pub async fn post<H: RoapiContext>(
     body: Bytes,
 ) -> Result<impl IntoResponse, ApiErrResp> {
     let ctx = state.0;
-    let encode_type = encode_type_from_hdr(headers);
+    let response_format = H::get_response_format(&ctx).await;
+    let encode_type = encode_type_from_hdr(headers, response_format);
     let graphq = std::str::from_utf8(&body).map_err(ApiErrResp::read_query)?;
     let batches = ctx.query_graphql(graphq).await?;
     encode_record_batches(encode_type, &batches)

--- a/roapi/src/api/mod.rs
+++ b/roapi/src/api/mod.rs
@@ -6,7 +6,6 @@ use axum::http::Response;
 use axum::response::IntoResponse;
 use columnq::datafusion::arrow;
 use columnq::encoding;
-use columnq::encoding::ContentType;
 
 use crate::error::ApiErrResp;
 
@@ -25,11 +24,14 @@ pub fn bytes_to_json_resp(bytes: Vec<u8>) -> impl IntoResponse {
     bytes_to_resp(bytes, "application/json")
 }
 
-pub fn encode_type_from_hdr(headers: header::HeaderMap) -> encoding::ContentType {
+pub fn encode_type_from_hdr(
+    headers: header::HeaderMap,
+    response_format: encoding::ContentType,
+) -> encoding::ContentType {
     match headers.get(header::ACCEPT) {
-        None => encoding::ContentType::Json,
+        None => response_format,
         Some(hdr_value) => {
-            encoding::ContentType::try_from(hdr_value.as_bytes()).unwrap_or(ContentType::Json)
+            encoding::ContentType::try_from(hdr_value.as_bytes()).unwrap_or(response_format)
         }
     }
 }

--- a/roapi/src/api/rest.rs
+++ b/roapi/src/api/rest.rs
@@ -14,7 +14,8 @@ pub async fn get_table<H: RoapiContext>(
     extract::Path(table_name): extract::Path<String>,
     extract::Query(params): extract::Query<HashMap<String, String>>,
 ) -> Result<impl IntoResponse, ApiErrResp> {
-    let encode_type = encode_type_from_hdr(headers);
+    let response_format = H::get_response_format(&ctx).await;
+    let encode_type = encode_type_from_hdr(headers, response_format);
     let batches = ctx.query_rest_table(&table_name, &params).await?;
     encode_record_batches(encode_type, &batches)
 }

--- a/roapi/src/api/sql.rs
+++ b/roapi/src/api/sql.rs
@@ -15,7 +15,8 @@ pub async fn post<H: RoapiContext>(
     body: Bytes,
 ) -> Result<impl IntoResponse, ApiErrResp> {
     let ctx = state.0;
-    let encode_type = encode_type_from_hdr(headers);
+    let response_format = H::get_response_format(&ctx).await;
+    let encode_type = encode_type_from_hdr(headers, response_format);
     let sql = std::str::from_utf8(&body).map_err(ApiErrResp::read_query)?;
     let batches = ctx.query_sql(sql).await?;
     encode_record_batches(encode_type, &batches)

--- a/roapi/src/config.rs
+++ b/roapi/src/config.rs
@@ -2,6 +2,7 @@ use serde_derive::Deserialize;
 
 use anyhow::{bail, Context, Result};
 
+use columnq::encoding;
 use columnq::table::parse_table_uri_arg;
 use columnq::table::KeyValueSource;
 use columnq::table::TableSource;
@@ -23,6 +24,7 @@ pub struct Config {
     pub disable_read_only: bool,
     #[serde(default)]
     pub kvstores: Vec<KeyValueSource>,
+    pub response_format: encoding::ContentType,
 }
 
 fn table_arg() -> clap::Arg<'static> {
@@ -75,6 +77,16 @@ fn reload_interval_arg() -> clap::Arg<'static> {
         .short('r')
 }
 
+fn response_format_arg() -> clap::Arg<'static> {
+    clap::Arg::new("response-format")
+        .help("change response serialization: Json (default), Csv, ArrowFile, ArrowStream, Parquet")
+        .required(false)
+        .takes_value(true)
+        .value_name("ResponseFormat")
+        .long("response-format")
+        .short('f')
+}
+
 fn config_arg() -> clap::Arg<'static> {
     clap::Arg::new("config")
         .help("config file path")
@@ -98,6 +110,7 @@ pub fn get_configuration() -> Result<Config, anyhow::Error> {
             config_arg(),
             read_only_arg(),
             reload_interval_arg(),
+            response_format_arg(),
             table_arg(),
         ])
         .get_matches();

--- a/roapi/src/config.rs
+++ b/roapi/src/config.rs
@@ -24,6 +24,7 @@ pub struct Config {
     pub disable_read_only: bool,
     #[serde(default)]
     pub kvstores: Vec<KeyValueSource>,
+    #[serde(default)]
     pub response_format: encoding::ContentType,
 }
 
@@ -150,6 +151,10 @@ pub fn get_configuration() -> Result<Config, anyhow::Error> {
         config.reload_interval = Some(Duration::from_secs(
             reload_interval.to_string().parse().unwrap(),
         ));
+    }
+
+    if let Some(response_format) = matches.value_of("response-format") {
+        config.response_format = serde_yaml::from_str(response_format)?;
     }
 
     Ok(config)

--- a/roapi/tests/helpers.rs
+++ b/roapi/tests/helpers.rs
@@ -33,8 +33,8 @@ pub async fn test_api_app(
         },
         tables,
         reload_interval: Some(Duration::from_secs(1000)),
-        disable_read_only: false,
         kvstores,
+        ..Default::default()
     };
 
     let app = Application::build(config)


### PR DESCRIPTION
Implementation of #212

I settled for using the enum names for configuration (Just _Json_ instead of _application/json_), I hope that's okay.

So this is an example of a working config:
```yaml
addr:
   http: 0.0.0.0:8070
response_format: ArrowStream
tables:
  - name: "colors"
    uri: "colors.csv"
```

