### PR TITLE
Added Pagination closes #229

### DIFF
--- a/columnq/src/query/graphql.rs
+++ b/columnq/src/query/graphql.rs
@@ -273,9 +273,7 @@ pub fn query_to_df(
             "limit" => {
                 limit = Some(value);
             }
-            "page" => {
-                page = Some(value)
-            }
+            "page" => page = Some(value),
             other => {
                 return Err(invalid_query(format!("invalid query argument: {}", other)));
             }
@@ -336,8 +334,8 @@ pub fn query_to_df(
     }
 
     // apply limit
-     // apply limit
-     if let Some(value) = limit {
+    // apply limit
+    if let Some(value) = limit {
         match value {
             Value::Int(n) => {
                 let skip = match page {
@@ -349,7 +347,7 @@ pub fn query_to_df(
                                     "invalid 64bits integer number in limit argument: {}",
                                     value,
                                 ))
-                            })?
+                            })? - 1
                         } else {
                             0
                         }
@@ -363,7 +361,7 @@ pub fn query_to_df(
                 })?;
                 df = df
                     .limit(
-                        skip as usize * limit as usize,
+                        (skip as usize) * limit as usize,
                         Some(usize::try_from(limit).map_err(|_| {
                             invalid_query(format!("limit value too large: {}", value))
                         })?),

--- a/columnq/src/query/graphql.rs
+++ b/columnq/src/query/graphql.rs
@@ -261,6 +261,7 @@ pub fn query_to_df(
     let mut filter = None;
     let mut sort = None;
     let mut limit = None;
+    let mut page = None;
     for (key, value) in &field.arguments {
         match *key {
             "filter" => {
@@ -271,6 +272,9 @@ pub fn query_to_df(
             }
             "limit" => {
                 limit = Some(value);
+            }
+            "page" => {
+                page = Some(value)
             }
             other => {
                 return Err(invalid_query(format!("invalid query argument: {}", other)));
@@ -332,9 +336,25 @@ pub fn query_to_df(
     }
 
     // apply limit
-    if let Some(value) = limit {
+     // apply limit
+     if let Some(value) = limit {
         match value {
             Value::Int(n) => {
+                let skip = match page {
+                    None => 0,
+                    Some(value) => {
+                        if let Value::Int(n) = value {
+                            n.as_i64().ok_or_else(|| {
+                                invalid_query(format!(
+                                    "invalid 64bits integer number in limit argument: {}",
+                                    value,
+                                ))
+                            })?
+                        } else {
+                            0
+                        }
+                    }
+                };
                 let limit = n.as_i64().ok_or_else(|| {
                     invalid_query(format!(
                         "invalid 64bits integer number in limit argument: {}",
@@ -343,7 +363,7 @@ pub fn query_to_df(
                 })?;
                 df = df
                     .limit(
-                        0,
+                        skip as usize * limit as usize,
                         Some(usize::try_from(limit).map_err(|_| {
                             invalid_query(format!("limit value too large: {}", value))
                         })?),

--- a/columnq/src/query/rest.rs
+++ b/columnq/src/query/rest.rs
@@ -161,7 +161,7 @@ pub fn table_query_to_df(
     if let Some(val) = params.get("limit") {
         let limit = val.parse::<usize>().map_err(num_parse_err)?;
         if let Some(val) = params.get("page") {
-            let skip = val.parse::<usize>().map_err(num_parse_err)? * limit;
+            let skip = (val.parse::<usize>().map_err(num_parse_err)? - 1) * limit;
             df = df
                 .limit(skip, Some(limit))
                 .map_err(QueryError::invalid_limit)?;

--- a/columnq/src/query/rest.rs
+++ b/columnq/src/query/rest.rs
@@ -160,7 +160,16 @@ pub fn table_query_to_df(
     // limit needs to be applied after sort to make sure the result is deterministics
     if let Some(val) = params.get("limit") {
         let limit = val.parse::<usize>().map_err(num_parse_err)?;
-        df = df.limit(0, Some(limit)).map_err(QueryError::invalid_limit)?;
+        if let Some(val) = params.get("page") {
+            let skip = val.parse::<usize>().map_err(num_parse_err)? * limit;
+            df = df
+                .limit(skip, Some(limit))
+                .map_err(QueryError::invalid_limit)?;
+        } else {
+            df = df
+                .limit(0, Some(limit))
+                .map_err(QueryError::invalid_limit)?;
+        }
     }
 
     Ok(df)

--- a/roapi/config.yml
+++ b/roapi/config.yml
@@ -1,0 +1,8 @@
+addr:
+  # binding address for TCP port that speaks HTTP protocol
+  http: 0.0.0.0:8084
+  # binding address for TCP port that speaks Postgres wire protocol
+  postgres: 0.0.0.0:5432
+tables:
+  - name: "blogs"
+    uri: "../test_data/blogs.parquet"

--- a/roapi/config.yml
+++ b/roapi/config.yml
@@ -1,8 +1,0 @@
-addr:
-  # binding address for TCP port that speaks HTTP protocol
-  http: 0.0.0.0:8084
-  # binding address for TCP port that speaks Postgres wire protocol
-  postgres: 0.0.0.0:5432
-tables:
-  - name: "blogs"
-    uri: "../test_data/blogs.parquet"


### PR DESCRIPTION
closes #229 
Supports `pagination` in `rest` and `graphql` endpoints when parameter `page` is passed along with `limit`.
Skips `(page-1)*limit` in table responses.

example:
```
localhost:8080/api/tables/table_name?limit=100&page=2
```
```
localhost:8080/api/graphql

body:
query { table_name(page:2, limit:100) {col1, col2} }
```

fetches next 100 responses from the table