### PR TITLE
#240 Set object_store minimal version and turn on aws_profile feature

### DIFF
--- a/columnq/Cargo.toml
+++ b/columnq/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/lib.rs"
 arrow-schema = { version ="26", features = ["serde"] }
 
 datafusion = "14"
-object_store = "0.5.0"
+object_store = { version = "0.5.3", features = ["aws_profile"] }
 url = "2.2"
 
 log = "0"

--- a/columnq/src/columnq.rs
+++ b/columnq/src/columnq.rs
@@ -29,12 +29,6 @@ impl ObjectStoreProvider for ColumnQObjectStoreProvider {
                 // for minio in CI
                 s3_builder = s3_builder.with_allow_http(true);
 
-                // TODO: can remove "with_endpoint" after object_store upgrade to 0.5.3
-                // https://github.com/apache/arrow-datafusion/pull/4929
-                if let Ok(endpoint) = std::env::var("AWS_ENDPOINT_URL") {
-                    s3_builder = s3_builder.with_endpoint(endpoint);
-                }
-
                 match s3_builder.build() {
                     Ok(s3) => Ok(Arc::new(s3)),
                     Err(err) => Err(DataFusionError::External(Box::new(err))),


### PR DESCRIPTION
### Why

address comment https://github.com/roapi/roapi/pull/245#issuecomment-1396487070

```
One thing I forgot to mention in the previous PR review, we should enable the aws-profile feature in the object store crate because using profile to inject credential is a very common pattern in AWS land.

Without this change, it will break the existing users that are using AWS profiles.
```