### PR TITLE
Update connector-x to latest commit of original repo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1123,8 +1123,8 @@ dependencies = [
 
 [[package]]
 name = "connectorx"
-version = "0.3.2-alpha.1"
-source = "git+https://github.com/roapi/connector-x.git?rev=66942bb65a7671cccb228ffe08fd99495430c103#66942bb65a7671cccb228ffe08fd99495430c103"
+version = "0.3.2-alpha.3"
+source = "git+https://github.com/sfu-db/connector-x.git?rev=962b396857979c813486ad842e91a0c21ce55f72#962b396857979c813486ad842e91a0c21ce55f72"
 dependencies = [
  "anyhow",
  "arrow",

--- a/columnq/Cargo.toml
+++ b/columnq/Cargo.toml
@@ -52,9 +52,9 @@ default-features = false
 features = ["datafusion-ext"]
 
 [dependencies.connectorx]
-git = "https://github.com/roapi/connector-x.git"
-rev = "66942bb65a7671cccb228ffe08fd99495430c103"
-version = "0.3.2-alpha.1"
+git = "https://github.com/sfu-db/connector-x.git"
+rev = "962b396857979c813486ad842e91a0c21ce55f72"
+version = "0.3.2-alpha.3"
 features = ["default", "dst_arrow"]
 optional = true
 


### PR DESCRIPTION
This updates `connextor-x` to the latest commit of the original repo to get the build working again.

`sfu-db/connector-x` has updated to to `r2d2_mysql` 23, the roapi fork was an update to version 22, so I think the fork is not needed anymore.

https://github.com/sfu-db/connector-x/blob/962b396857979c813486ad842e91a0c21ce55f72/connectorx/Cargo.toml#L46

https://github.com/roapi/connector-x/commit/31d2730845d4bc97f1b29a5516ed6f1c11d58594

Closes #271