### PR TITLE
Support for Dynamic Table Deletion #340

### DIFF
--- a/columnq/src/columnq.rs
+++ b/columnq/src/columnq.rs
@@ -110,6 +110,12 @@ impl ColumnQ {
         Ok(())
     }
 
+    pub async fn drop_table(&mut self, t: &TableSource) -> Result<(), ColumnQError> {
+        self.schema_map.remove(&t.name);
+        self.dfctx.deregister_table(t.name.as_str())?;
+        Ok(())
+    }
+
     pub fn register_object_storage(
         &mut self,
         url: &Url,

--- a/roapi/src/api/drop.rs
+++ b/roapi/src/api/drop.rs
@@ -1,6 +1,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use axum::extract::{Extension, Json};
+use columnq::error::ColumnQError;
 use columnq::table::TableSource;
 use log::info;
 use serde::Deserialize;
@@ -16,17 +17,22 @@ pub struct SourceConfig {
 }
 
 pub async fn drop_table<H: RoapiContext>(
+    Extension(ctx): Extension<Arc<H>>,
     Extension(tables): Extension<Arc<Mutex<HashMap<String, TableSource>>>>,
     Json(body): Json<Vec<SourceConfig>>,
 ) -> Result<(), ApiErrResp> {
     let mut tables = tables.lock().await;
     for config in body {
-        if tables.contains_key(&config.table_name) {
-            info!("dropping table `{}`", config.table_name);
+        if let Some(t) = tables.get(&config.table_name) {
+            info!("dropping table `{}`", t.name);
+            ctx.drop_table(&t)
+                .await
+                .map_err(ColumnQError::from)
+                .map_err(ApiErrResp::drop_table)?;
             tables.remove(&config.table_name);
             info!("dropped table `{}`", config.table_name);
         } else {
-            return Err(ApiErrResp::register_table(format!(
+            return Err(ApiErrResp::not_found(format!(
                 "Table `{}` source does not exist",
                 config.table_name
             )));

--- a/roapi/src/api/drop.rs
+++ b/roapi/src/api/drop.rs
@@ -25,7 +25,7 @@ pub async fn drop_table<H: RoapiContext>(
     for config in body {
         if let Some(t) = tables.get(&config.table_name) {
             info!("dropping table `{}`", t.name);
-            ctx.drop_table(&t)
+            ctx.drop_table(t)
                 .await
                 .map_err(ColumnQError::from)
                 .map_err(ApiErrResp::drop_table)?;

--- a/roapi/src/api/drop.rs
+++ b/roapi/src/api/drop.rs
@@ -1,0 +1,40 @@
+use std::{collections::HashMap, sync::Arc};
+
+use axum::extract::{Extension, Json};
+use columnq::table::TableSource;
+use log::info;
+use serde::Deserialize;
+use tokio::sync::Mutex;
+
+use crate::context::RoapiContext;
+use crate::error::ApiErrResp;
+
+#[derive(Debug, Deserialize)]
+pub struct SourceConfig {
+    #[serde(rename = "tableName")]
+    pub table_name: String,
+}
+
+pub async fn drop_table<H: RoapiContext>(
+    Extension(tables): Extension<Arc<Mutex<HashMap<String, TableSource>>>>,
+    Json(body): Json<Vec<SourceConfig>>,
+) -> Result<(), ApiErrResp> {
+    let mut tables = tables.lock().await;
+    for config in body {
+        if tables.contains_key(&config.table_name) {
+            info!("dropping table `{}`", config.table_name);
+            tables.remove(&config.table_name);
+            info!("dropped table `{}`", config.table_name);
+        } else {
+            return Err(ApiErrResp::register_table(format!(
+                "Table `{}` source does not exist",
+                config.table_name
+            )));
+        }
+    }
+    Ok(())
+}
+
+pub async fn drop_table_read_only() -> Result<(), ApiErrResp> {
+    Err(ApiErrResp::read_only_mode())
+}

--- a/roapi/src/api/mod.rs
+++ b/roapi/src/api/mod.rs
@@ -56,6 +56,7 @@ pub fn encode_record_batches(
     Ok(bytes_to_resp(payload, content_type.to_str()))
 }
 
+pub mod drop;
 pub mod graphql;
 pub mod health;
 pub mod kv;

--- a/roapi/src/api/routes.rs
+++ b/roapi/src/api/routes.rs
@@ -20,9 +20,13 @@ pub fn register_app_routes<H: RoapiContext>() -> Router {
         );
 
     if H::read_only_mode() {
-        router = router.route("/api/table", post(api::register::register_table_read_only));
+        router = router
+            .route("/api/table", post(api::register::register_table_read_only))
+            .route("/api/tables/drop", post(api::drop::drop_table_read_only));
     } else {
-        router = router.route("/api/table", post(api::register::register_table::<H>));
+        router = router
+            .route("/api/table", post(api::register::register_table::<H>))
+            .route("/api/tables/drop", post(api::drop::drop_table::<H>));
     }
 
     router

--- a/roapi/src/context.rs
+++ b/roapi/src/context.rs
@@ -62,6 +62,8 @@ pub trait RoapiContext: Send + Sync + 'static {
 
     async fn load_table(&self, table: &TableSource) -> Result<(), ColumnQError>;
 
+    async fn drop_table(&self, table: &TableSource) -> Result<(), ColumnQError>;
+
     async fn schemas(&self) -> Result<Vec<(String, arrow::datatypes::SchemaRef)>, ApiErrResp>;
 
     async fn schemas_json_bytes(&self) -> Result<Vec<u8>, ApiErrResp>;
@@ -103,6 +105,13 @@ impl RoapiContext for RawRoapiContext {
 
     #[inline]
     async fn load_table(&self, _table: &TableSource) -> Result<(), ColumnQError> {
+        Err(ColumnQError::Generic(
+            "Table update not supported in read only mode".to_string(),
+        ))
+    }
+
+    #[inline]
+    async fn drop_table(&self, _table: &TableSource) -> Result<(), ColumnQError> {
         Err(ColumnQError::Generic(
             "Table update not supported in read only mode".to_string(),
         ))
@@ -207,6 +216,12 @@ impl RoapiContext for ConcurrentRoapiContext {
     async fn load_table(&self, table: &TableSource) -> Result<(), ColumnQError> {
         let mut ctx = self.write().await;
         ctx.cq.load_table(table).await
+    }
+
+    #[inline]
+    async fn drop_table(&self, table: &TableSource) -> Result<(), ColumnQError> {
+        let mut ctx = self.write().await;
+        ctx.cq.drop_table(table).await
     }
 
     #[inline]

--- a/roapi/src/error.rs
+++ b/roapi/src/error.rs
@@ -89,6 +89,14 @@ impl ApiErrResp {
         }
     }
 
+    pub fn drop_table(error: String) -> Self {
+        Self {
+            code: http::StatusCode::INTERNAL_SERVER_ERROR,
+            error: "drop_table".to_string(),
+            message: error,
+        }
+    }
+
     pub fn read_only_mode() -> Self {
         Self {
             code: http::StatusCode::FORBIDDEN,

--- a/roapi/src/error.rs
+++ b/roapi/src/error.rs
@@ -89,19 +89,19 @@ impl ApiErrResp {
         }
     }
 
-    pub fn drop_table(error: String) -> Self {
-        Self {
-            code: http::StatusCode::INTERNAL_SERVER_ERROR,
-            error: "drop_table".to_string(),
-            message: error,
-        }
-    }
-
     pub fn read_only_mode() -> Self {
         Self {
             code: http::StatusCode::FORBIDDEN,
             error: "read_only_mode".to_string(),
             message: "Write operation is not allowed in read-only mode".to_string(),
+        }
+    }
+
+    pub fn drop_table(error: ColumnQError) -> Self {
+        Self {
+            code: http::StatusCode::INTERNAL_SERVER_ERROR,
+            error: "drop_table".to_string(),
+            message: error.to_string(),
         }
     }
 

--- a/roapi/tests/helpers.rs
+++ b/roapi/tests/helpers.rs
@@ -35,6 +35,7 @@ pub async fn test_api_app(
         },
         tables,
         reload_interval: Some(Duration::from_secs(1000)),
+        disable_read_only: true,
         kvstores,
         ..Default::default()
     };
@@ -62,6 +63,17 @@ pub async fn http_get(url: &str, accept: Option<&str>) -> reqwest::Response {
 pub async fn http_post(url: &str, payload: impl Into<reqwest::Body>) -> reqwest::Response {
     reqwest::Client::new()
         .post(url)
+        .body(payload)
+        .send()
+        .await
+        .expect("Unable to execute POST request")
+}
+
+#[allow(dead_code)]
+pub async fn http_post_json(url: &str, payload: impl Into<reqwest::Body>) -> reqwest::Response {
+    reqwest::Client::new()
+        .post(url)
+        .header("Content-Type", "application/json")
         .body(payload)
         .send()
         .await


### PR DESCRIPTION
#340 
I did my best to mirror the `register_table` endpoint. 
Note that for the test to work I had to set `disable_read_only=true` in the `test_api_app helper` function.

I'm fairly new to Rust so any feedback is appreciated.