### PR TITLE
columnq: add `apply_query()` and `exec_query_with_df()` to query::graphql module

### DIFF
--- a/columnq/src/query/graphql.rs
+++ b/columnq/src/query/graphql.rs
@@ -379,7 +379,7 @@ pub async fn exec_query(
 
 /// Executes a GraphQL query using the provided DataFrame.
 pub async fn exec_query_with_df(
-    df: &datafusion::dataframe::DataFrame,
+    df: datafusion::dataframe::DataFrame,
     query: &str,
 ) -> Result<Vec<arrow::record_batch::RecordBatch>, QueryError> {
     apply_query(df.clone(), query)?

--- a/columnq/src/query/graphql.rs
+++ b/columnq/src/query/graphql.rs
@@ -145,7 +145,9 @@ fn to_datafusion_predicates(col: &str, filter: &Value<String>) -> Result<Vec<Exp
     }
 }
 
-fn parse_field(query: &str) -> Result<graphql_parser::query::Field<'_, String>, QueryError> {
+pub fn parse_query_to_field(
+    query: &str,
+) -> Result<graphql_parser::query::Field<'_, String>, QueryError> {
     let doc = parse_query::<String>(query)?;
 
     let def = match doc.definitions.len() {
@@ -345,7 +347,7 @@ pub fn apply_query(
     df: datafusion::dataframe::DataFrame,
     query: &str,
 ) -> Result<datafusion::dataframe::DataFrame, QueryError> {
-    let field = parse_field(query)?;
+    let field = parse_query_to_field(query)?;
     apply_field_to_df(df, field)
 }
 
@@ -354,7 +356,7 @@ pub async fn query_to_df(
     dfctx: &datafusion::execution::context::SessionContext,
     query: &str,
 ) -> Result<datafusion::dataframe::DataFrame, QueryError> {
-    let field = parse_field(query)?;
+    let field = parse_query_to_field(query)?;
     let df = dfctx
         .table(field.name.as_str())
         .await


### PR DESCRIPTION
Hello,

This PR exposes two functions from the `columnq::query::graphql` module:

- `apply_query()`
- `exec_query_with_df()`

These functions are similar to `query_to_df()` and `exec_query()`, but they accept a `DataFrame` instead of a `SessionContext`.

This is  useful for defining rules directly within a `DataFrame` without modifying the table schema in DataFusion's session context.