### PR TITLE
columnq: add `apply_query()` and `exec_query_with_df()` to query::rest module

### DIFF
--- a/columnq/src/columnq.rs
+++ b/columnq/src/columnq.rs
@@ -254,7 +254,7 @@ impl ColumnQ {
         table_name: &str,
         params: &HashMap<String, String>,
     ) -> Result<Vec<arrow::record_batch::RecordBatch>, QueryError> {
-        query::rest::query_table(&self.dfctx, table_name, params).await
+        query::rest::exec_table_query(&self.dfctx, table_name, params).await
     }
 
     pub fn kv_get(&self, kv_name: &str, key: &str) -> Result<Option<&String>, QueryError> {


### PR DESCRIPTION
Hello,

Following this PR #348 

This PR exposes two functions from the columnq::query::rest module:

    apply_query()
    exec_query_with_df()

This PR also includes breaking changes to ensure consistency with the function names in the `columnq::query::graphql` module. I renamed the function `query_table` to `exec_table_query`.
