### PR TITLE
fix: add missing explicit lifetime in `ExcelSubrange` return type for rust 1.83 build

### DIFF
--- a/columnq/src/table/excel.rs
+++ b/columnq/src/table/excel.rs
@@ -45,7 +45,7 @@ impl<'a> ExcelSubrange<'a> {
         rows_range_end: Option<usize>,
         columns_range_start: Option<usize>,
         columns_range_end: Option<usize>,
-    ) -> ExcelSubrange {
+    ) -> ExcelSubrange<'a> {
         let rows_range_start = rows_range_start.unwrap_or(usize::MIN);
         let rows_range_end = rows_range_end
             .or(range.end().map(|v| v.0 as usize))


### PR DESCRIPTION
seeing some regression build failure when building roapi 0.12.0 against rust 1.83.0

```
  error: elided lifetime has a name
    --> columnq/src/table/excel.rs:48:10
     |
  41 | impl<'a> ExcelSubrange<'a> {
     |      -- lifetime `'a` declared here
  ...
  48 |     ) -> ExcelSubrange {
     |          ^^^^^^^^^^^^^ this elided lifetime gets resolved as `'a`
     |
  note: the lint level is defined here
    --> columnq/src/lib.rs:1:9
     |
  1  | #![deny(warnings)]
     |         ^^^^^^^^
     = note: `#[deny(elided_named_lifetimes)]` implied by `#[deny(warnings)]`
```

relates to https://github.com/Homebrew/homebrew-core/pull/199379