### PR TITLE
columnq - issue with the argument types

### DIFF
--- a/columnq-cli/src/main.rs
+++ b/columnq-cli/src/main.rs
@@ -90,7 +90,7 @@ async fn cmd_console(args: &clap::ArgMatches) -> anyhow::Result<()> {
     let config = SessionConfig::default().with_information_schema(true);
     let mut cq = ColumnQ::new_with_config(config, true);
 
-    if let Some(tables) = args.get_many::<&str>("table") {
+    if let Some(tables) = args.get_many::<String>("table") {
         for v in tables {
             cq.load_table(&parse_table_uri_arg(v)?).await?;
         }
@@ -110,33 +110,33 @@ async fn cmd_sql(args: &clap::ArgMatches) -> anyhow::Result<()> {
     let config = SessionConfig::default().with_information_schema(true);
     let mut cq = ColumnQ::new_with_config(config, true);
 
-    if let Some(tables) = args.get_many::<&str>("table") {
+    if let Some(tables) = args.get_many::<String>("table") {
         for v in tables {
             cq.load_table(&parse_table_uri_arg(v)?).await?;
         }
     }
 
-    match args.get_one::<&str>("SQL") {
+    match args.get_one::<String>("SQL") {
         Some(query) => match cq.query_sql(query).await {
-            Ok(batches) => match args.get_one::<&str>("output").unwrap_or(&"table") {
-                &"table" => pretty::print_batches(&batches)?,
-                &"json" => {
+            Ok(batches) => match args.get_one::<String>("output").unwrap_or(&String::from("table")).as_str() {
+                "table" => pretty::print_batches(&batches)?,
+                "json" => {
                     let bytes = encoding::json::record_batches_to_bytes(&batches)?;
                     bytes_to_stdout(&bytes)?;
                 }
-                &"csv" => {
+                "csv" => {
                     let bytes = encoding::csv::record_batches_to_bytes(&batches)?;
                     bytes_to_stdout(&bytes)?;
                 }
-                &"parquet" => {
+                "parquet" => {
                     let bytes = encoding::parquet::record_batches_to_bytes(&batches)?;
                     bytes_to_stdout(&bytes)?;
                 }
-                &"arrow" => {
+                "arrow" => {
                     let bytes = encoding::arrow::record_batches_to_file_bytes(&batches)?;
                     bytes_to_stdout(&bytes)?;
                 }
-                &"arrows" => {
+                "arrows" => {
                     let bytes = encoding::arrow::record_batches_to_stream_bytes(&batches)?;
                     bytes_to_stdout(&bytes)?;
                 }

--- a/columnq-cli/src/main.rs
+++ b/columnq-cli/src/main.rs
@@ -118,7 +118,11 @@ async fn cmd_sql(args: &clap::ArgMatches) -> anyhow::Result<()> {
 
     match args.get_one::<String>("SQL") {
         Some(query) => match cq.query_sql(query).await {
-            Ok(batches) => match args.get_one::<String>("output").unwrap_or(&String::from("table")).as_str() {
+            Ok(batches) => match args
+                .get_one::<String>("output")
+                .unwrap_or(&String::from("table"))
+                .as_str()
+            {
                 "table" => pretty::print_batches(&batches)?,
                 "json" => {
                     let bytes = encoding::json::record_batches_to_bytes(&batches)?;


### PR DESCRIPTION
Thank you for the project!

I was using the columnq v0.5.2 and getting the following error:

```
thread 'main' panicked at /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap_builder-4.5.2/src/parser/error.rs:32:9:
Mismatch between definition and access of `table`. Could not downcast to TypeId { t: 337271291176647618489964333718931667905 }, need to downcast to TypeId { t: 150318335506304927533756938025983212585 }
```

Looks like the argument types needed to be updated to String. The roapi source was already using String - like the following:

```
    if let Some(tables) = matches.get_many::<String>("table") {
        for v in tables {
            config.tables.push(whatever!(
                parse_table_uri_arg(v),
                "Failed to parse table uri: {v}"
            ));
        }
    }
```


