### PR TITLE
README - Change default HTTP port

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ advanced format specific table options:
 
 ```yaml
 addr:
-  http: 0.0.0.0:8084
+  http: 0.0.0.0:8080
   postgres: 0.0.0.0:5433
 tables:
   - name: "blogs"


### PR DESCRIPTION
Update the example HTTP port in the configuration sample to match other query/cli examples in the README file.

All examples used port `8080`, but we have `8084` in the configuration example. This is not a major issue, but if the ports are the same everywhere, it will be easier for new users to run the project and test the examples.

The main documentation has also been updated in [this PR](https://github.com/roapi/docs/pull/21).