### PR TITLE
Add HTTP `object_store` to be able to connect without caching in memory…

### DIFF
--- a/columnq/Cargo.toml
+++ b/columnq/Cargo.toml
@@ -44,7 +44,7 @@ reqwest = { version = "0", default-features = false, features = [
 hyper-tls = { version = "0", default-features = false, optional = true }
 hyper-rustls = { version = "0", default-features = false, optional = true }
 
-object_store = { version = "0.11", features = ["aws", "gcp", "azure"] }
+object_store = { version = "0.11", features = ["http", "aws", "gcp", "azure"] }
 tokio-postgres = { version = "0.7.12", optional = true }
 deltalake = { version = "0.22", features = [
     "datafusion",

--- a/columnq/src/io/mod.rs
+++ b/columnq/src/io/mod.rs
@@ -62,6 +62,7 @@ impl TryFrom<&str> for BlobStoreType {
 
     fn try_from(scheme: &str) -> Result<Self, Self::Error> {
         match scheme {
+            "http" | "https" => Ok(BlobStoreType::Http), 
             "s3" => Ok(BlobStoreType::S3),
             "gs" => Ok(BlobStoreType::GCS),
             "az" | "adl" | "adfs" | "adfss" | "azure" => Ok(BlobStoreType::Azure),
@@ -104,5 +105,15 @@ mod tests {
         let uri_ref = URIReference::try_from("/tmp/path/to/file.csv").unwrap();
         let blob_type = BlobStoreType::try_from(uri_ref.scheme()).unwrap();
         assert_eq!(blob_type, BlobStoreType::FileSystem);
+
+        // *http
+        let uri_ref = URIReference::try_from("http://tmp/path/to/file.csv").unwrap();
+        let blob_type = BlobStoreType::try_from(uri_ref.scheme()).unwrap();
+        assert_eq!(blob_type, BlobStoreType::Http);
+
+        // *https
+        let uri_ref = URIReference::try_from("https://tmp/path/to/file.csv").unwrap();
+        let blob_type = BlobStoreType::try_from(uri_ref.scheme()).unwrap();
+        assert_eq!(blob_type, BlobStoreType::Http);
     }
 }


### PR DESCRIPTION
Before: 
```
roapi -t taxi=https://d37ci6vzurychx.cloudfront.net/trip-data/yellow_tripdata_2024-01.parquet,use_memory_table=false,format=parquet
[2025-04-23T22:43:25Z INFO  roapi::context] loading `uri(https://d37ci6vzurychx.cloudfront.net/trip-data/yellow_tripdata_2024-01.parquet)` as table `taxi`
error: Failed to build context: Failed to load table: Table error: Failed to infer table schema: Internal error: No suitable object store found for https://d37ci6vzurychx.cloudfront.net/trip-data/yellow_tripdata_2024-01.parquet. See `RuntimeEnv::register_object_store`.
This was likely caused by a bug in DataFusion's code and we would welcome that you file an bug report in our issue tracker
```

After:
```
roapi -t 'taxi=https://d37ci6vzurychx.cloudfront.net/trip-data/yellow_tripdata_2024-01.parquet,use_memory_table=false,format=parquet'`
[2025-04-23T22:47:00Z INFO  roapi::context] loading `uri(https://d37ci6vzurychx.cloudfront.net/trip-data/yellow_tripdata_2024-01.parquet)` as table `taxi`
[2025-04-23T22:47:00Z INFO  roapi::context] registered `uri(https://d37ci6vzurychx.cloudfront.net/trip-data/yellow_tripdata_2024-01.parquet)` as table `taxi`
[2025-04-23T22:47:00Z INFO  roapi::startup] Running in read-only mode.
[2025-04-23T22:47:00Z INFO  roapi::startup] 🚀 Listening on 127.0.0.1:5432 for Postgres traffic...
[2025-04-23T22:47:00Z INFO  roapi::startup] 🚀 Listening on 127.0.0.1:32010 for FlightSQL traffic...
[2025-04-23T22:47:00Z INFO  roapi::startup] 🚀 Listening on 127.0.0.1:8080 for HTTP traffic...
```