### PR TITLE
Ignore `SET key = 'value'` queries on PostgreSQL interface

### DIFF
--- a/roapi/src/server/postgres.rs
+++ b/roapi/src/server/postgres.rs
@@ -116,7 +116,8 @@ impl<H: RoapiContext> RoapiQueryHandler<H> {
         info!("executing query: {query}");
 
         // Handle some special PostgreSQL queries
-        if query.trim().to_lowercase().starts_with("show") {
+        let query_normalized = query.trim().to_lowercase();
+        if query_normalized.starts_with("show") || query_normalized.starts_with("set") {
             let empty_schema = Arc::new(vec![]);
             let empty_stream = stream::iter(vec![]);
             return Ok(QueryResponse::new(empty_schema, empty_stream));


### PR DESCRIPTION
## Problem
CrateDB's built-in PostgreSQL JDBC FDW connector emits this SQL statement, which currently fails on ROAPI:
```sql
SET application_name = 'PostgreSQL JDBC Driver'
```

## Solution
Ignore all `SET key = 'value'` queries, or, to be more precise, all queries starting with `SET`. Is it too harsh?

## References
- GH-415
- https://github.com/crate/cratedb-examples/pull/1286#pullrequestreview-3549651369
