### PR TITLE
OCI: Add `curl` program, to unlock Docker Compose health checks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ FROM debian:bookworm-slim
 LABEL org.opencontainers.image.source=https://github.com/roapi/roapi
 
 RUN apt-get update \
-    && apt-get install -y libssl-dev ca-certificates \
+    && apt-get install -y libssl-dev ca-certificates curl \
     && rm -rf /var/lib/apt/lists/*
 COPY test_data /test_data
 COPY --from=builder /roapi_src/target/release/roapi /usr/local/bin/roapi


### PR DESCRIPTION
## About
The existing healtcheck endpoint http://localhost:8080/health can now be used without much ado within Docker Compose service definitions, and it works well.

```yaml
healthcheck:
  test: ["CMD", "curl", "--fail", "http://localhost:8080/health"]
  start_period: 3s
  interval: 1.5s
  retries: 30
  timeout: 30s
```

## References
- Resolves: https://github.com/roapi/roapi/issues/418
- See also: https://github.com/crate/cratedb-examples/pull/1320#pullrequestreview-3601457082